### PR TITLE
[UPD] Actualizar los nuevos planes de ETECSA

### DIFF
--- a/config.json
+++ b/config.json
@@ -9,12 +9,12 @@
       "code": "*222#"
     },
     {
-      "name": "Consultar bono",
-      "description": "Consulta el estado de tu bono (Ej: El bono .cu)",
-      "icon": "star_border",
+      "name": "Estado de recargas",
+      "description": "Consulta el estado de tus recargas nacionales",
+      "icon": "attach_money",
       "type": "code",
       "fields": [],
-      "code": "*222*266#"
+      "code": "*222*732#"
     },
     {
       "name": "Asterisco 99",
@@ -142,6 +142,14 @@
           "code": "*222#"
         },
         {
+          "name": "Estado de recargas",
+          "description": "Consulta el estado de tus recargas nacionales",
+          "icon": "attach_money",
+          "type": "code",
+          "fields": [],
+          "code": "*222*732#"
+        },
+        {
           "name": "Recargar",
           "description": "Recarga tu línea fácilmente",
           "icon": "monetization_on",
@@ -233,130 +241,50 @@
       "type": "category",
       "items": [
         {
-          "name": "Planes Combinados",
+          "name": "Planes con Datos",
           "description": "Gestiona tu plan combinado de Datos+Voz+SMS",
           "icon": "data_usage",
           "type": "category",
           "items": [
             {
-              "name": "Consultar saldo y planes contratados",
-              "description": "Consulta tu saldo y planes contratados, todo a la vez",
-              "icon": "attach_money",
-              "type": "code",
-              "fields": [],
-              "code": "*222#"
-            },
-            {
-              "name": "600 MB + 800 MB solo LTE - $110 CUP",
-              "description": "+ 15min VOZ + 20 SMS + 300 MB .cu",
+              "name": "Bolsa Diaria - $25 CUP",
+              "description": "200 MB (vence en 24h)",
               "icon": "data_usage",
               "type": "code",
               "fields": [],
-              "code": "*133*5*1#"
+              "code": "*133*1*3#"
             },
             {
-              "name": "1.5 GB + 2 GB solo LTE - $250 CUP",
-              "description": "+ 35min VOZ + 40 SMS + 300 MB .cu",
+              "name": "4.5 GB - $240 CUP",
+              "description": "",
               "icon": "data_usage",
               "type": "code",
               "fields": [],
-              "code": "*133*5*2#"
+              "code": "*133*1*4*1#"
             },
             {
-              "name": "3.5 GB + 4.5 GB solo LTE - $500 CUP",
-              "description": "+ 75min VOZ + 80 SMS + 300 MB .cu",
+              "name": "2 GB - $120 CUP",
+              "description": "+ 15 min + 20 SMS",
               "icon": "data_usage",
               "type": "code",
               "fields": [],
-              "code": "*133*5*3#"
-            }
-          ]
-        },
-        {
-          "name": "Planes de Datos",
-          "description": "Gestiona tu plan de datos",
-          "icon": "data_usage",
-          "type": "category",
-          "items": [
+              "code": "*133*1*4*2#"
+            },
             {
-              "name": "Megas disponibles",
-              "description": "Consulta tus megas disponibles",
+              "name": "4 GB - $240 CUP",
+              "description": "+ 35 min + 40 SMS",
               "icon": "data_usage",
               "type": "code",
               "fields": [],
-              "code": "*222*328#"
+              "code": "*133*1*4*3#"
             },
             {
-              "name": "Tarifa por consumo",
-              "description": "Consumir directo del saldo",
-              "icon": "network_cell",
-              "type": "category",
-              "items": [
-                {
-                  "name": "Habilitar",
-                  "description": "",
-                  "icon": "network_cell",
-                  "type": "code",
-                  "fields": [],
-                  "code": "*133*1*1*1#"
-                },
-                {
-                  "name": "Deshabilitar",
-                  "description": "",
-                  "icon": "network_locked",
-                  "type": "code",
-                  "fields": [],
-                  "code": "*133*1*1*2#"
-                }
-              ]
-            },
-            {
-              "name": "Bolsa Mensajeria - $25 CUP",
-              "description": "Paquete de 600 MB sólo para toDus y correo nauta",
-              "icon": "mail",
+              "name": "6 GB - $360 CUP",
+              "description": "+ 60 min + 70 SMS",
+              "icon": "data_usage",
               "type": "code",
               "fields": [],
-              "code": "*133*1*2#"
-            },
-            {
-              "name": "SOLO Líneas USIM con LTE (nuevas)",
-              "description": "Paquetes de internet para usuarios que tienen activado el servicio LTE.",
-              "icon": "data_usage",
-              "type": "category",
-              "items": [
-                {
-                  "name": "Bolsa Diaria - $25 CUP",
-                  "description": "200 MB (vence en 24h)",
-                  "icon": "data_usage",
-                  "type": "code",
-                  "fields": [],
-                  "code": "*133*1*3#"
-                },
-                {
-                  "name": "1 GB solo LTE - $100 CUP",
-                  "description": "+300 MB bono .cu",
-                  "icon": "data_usage",
-                  "type": "code",
-                  "fields": [],
-                  "code": "*133*1*4*1#"
-                },
-                {
-                  "name": "2.5 GB solo LTE - $200 CUP",
-                  "description": "+300 MB bono .cu",
-                  "icon": "data_usage",
-                  "type": "code",
-                  "fields": [],
-                  "code": "*133*1*4*2#"
-                },
-                {
-                  "name": "4 GB + 12 GB solo LTE - $950 CUP",
-                  "description": "+300 MB bono .cu",
-                  "icon": "data_usage",
-                  "type": "code",
-                  "fields": [],
-                  "code": "*133*1*4*3#"
-                }
-              ]
+              "code": "*133*1*4*4#"
             }
           ]
         },


### PR DESCRIPTION
## Contexto

ETECSA recientemente actualizó los planes de datos y eliminó la distinción entre los GB para LTE y el resto de las redes.

Se puede encontrar más información en los siguientes enlaces
- [¿Qué necesitas saber?](https://www.etecsa.cu/sites/default/files/inline-files/Servicio%20de%20telefonia%20movil_PDF_1.pdf)
- [Artículo de Cubadebate](http://www.cubadebate.cu/noticias/2025/05/30/etecsa-modifica-sus-ofertas-para-el-servicio-movil-prepago-desde-este-30-de-mayo-que-pasara-ahora-con-las-recargas-y-los-planes-infografias/)

## Cambios
- Actualizados los códigos y descripciones para comprar los nuevos planes de datos
- Agregado el código USSD para la consulta del estado mensual de las recargas

**NOTA:** Sería bueno confirmar que los códigos USSD agregados son correctos ya que no dispongo de una línea de ETECSA para confirmarlo.